### PR TITLE
Add QC metrics and improve efficiency in ONT assembly, lineage, and transfer WDLs

### DIFF
--- a/workflows/WDLs/SC2_lineage_calling_and_results.wdl
+++ b/workflows/WDLs/SC2_lineage_calling_and_results.wdl
@@ -114,7 +114,7 @@ task concatenate {
         docker: "ubuntu"
         memory: "1 GB"
         cpu:    1
-        disks: "local-disk 375 LOCAL"
+        disks: "local-disk 10 SSD"
         dx_instance_type: "mem1_ssd1_v2_x2"
     }
 }

--- a/workflows/WDLs/SC2_lineage_calling_and_results.wdl
+++ b/workflows/WDLs/SC2_lineage_calling_and_results.wdl
@@ -259,7 +259,7 @@ task results_table {
         docker: "mchether/py3-bio:v2"
         memory: "16 GB"
         cpu:    4
-        disks: "local-disk 375 LOCAL"
+        disks: "local-disk 100 SSD"
         dx_instance_type: "mem1_ssd1_v2_x2"
     }
 }

--- a/workflows/WDLs/SC2_lineage_calling_and_results.wdl
+++ b/workflows/WDLs/SC2_lineage_calling_and_results.wdl
@@ -7,7 +7,6 @@ workflow SC2_lineage_calling_and_results {
         Array[File?] assembly_fastas
         Array[File?] cov_out_txt
         Array[File?] percent_cvg_csv
-        File covid_genome
         File nextclade_json_parser_script
         File concat_results_script
         Array[String] out_dir
@@ -130,7 +129,9 @@ task pangolin {
     command {
 
         pangolin --version > VERSION
-        pangolin --skip-scorpio --expanded-lineage --outfile pangolin_lineage_report.csv ${cat_fastas}
+        
+        pangolin --skip-scorpio --expanded-lineage --threads 32 \
+            --outfile pangolin_lineage_report.csv ${cat_fastas}
 
     }
 
@@ -142,7 +143,7 @@ task pangolin {
     }
 
     runtime {
-        cpu:    4
+        cpu:    32
         memory:    "16 GiB"
         disks:    "local-disk 1 HDD"
         bootDiskSizeGb:    10

--- a/workflows/WDLs/SC2_lineage_calling_and_results.wdl
+++ b/workflows/WDLs/SC2_lineage_calling_and_results.wdl
@@ -129,7 +129,7 @@ task pangolin {
     command {
 
         pangolin --version > VERSION
-        
+
         pangolin --skip-scorpio --expanded-lineage --threads 32 \
             --outfile pangolin_lineage_report.csv ${cat_fastas}
 
@@ -298,6 +298,6 @@ task transfer {
         docker: "theiagen/utility:1.0"
         memory: "16 GB"
         cpu: 4
-        disks: "local-disk 10 SSD"
+        disks: "local-disk 100 SSD"
     }
 }

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -247,7 +247,7 @@ task Bam_stats {
         # Calculate depth of coverage over S gene amplicon regions (excludes overlapping regions with adjacent amplicons)
         echo "calculating depths for ~{s_gene_amplicons}"
         {
-            s_gene_depths="~{sample_id}_s_gene_depths.tsv"
+            s_gene_depths="~{sample_id}_S_gene_depths.tsv"
 
             # write header line to s_gene_depths output file
             read header

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -266,11 +266,11 @@ task Bam_stats {
         S_gene_amplicons['amplicon_83']='24,815-25,076'
         S_gene_amplicons['amplicon_84']='25,123-25,353'  # ER export motif, membrane localizing domain binding
 
-        for region in "${!S_gene_amplicons[@]}"; do
-            samtools coverage \
-                --region MN908947.3:${S_gene_amplicons[$region]} ${bam} \
-                -o ${sample_id}_${barcode}_${region}_coverage.txt ${bam}
-        done
+        # for region in "${!S_gene_amplicons[@]}"; do
+        #     samtools coverage \
+        #         --region MN908947.3:${S_gene_amplicons[$region]} ${bam} \
+        #         -o ${sample_id}_${barcode}_${region}_coverage.txt ${bam}
+        # done
     }
 
     output {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -42,8 +42,7 @@ workflow SC2_ont_assembly {
             bai = Medaka.trimsort_bai,
             sample_id = sample_id,
             barcode = barcode,
-            amplicon_names = amplicon_names,
-            amplicon_coords = amplicon_coords
+            s_gene_amplicons = s_gene_amplicons
             
     }
     call Scaffold {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -230,16 +230,16 @@ task Bam_stats {
 
         # Calculate depth of coverage over entire S gene
         samtools coverage --region MN908947.3:21,563-25,384 \
-            -o {sample_id}_${barcode}_S_gene_coverage.txt ${bam}
+            -o ${sample_id}_${barcode}_S_gene_coverage.txt ${bam}
 
         # Calculate depth of coverage over S gene amplicon region containing aa positions 69 and 70
         samtools coverage --region MN908947.3:21,676-21,889 \
-            -o {sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt ${bam}
+            -o ${sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt ${bam}
 
 
         # Calculate depth of coverage over S gene amplicon region with Artic V4.1 XBB dropout
         samtools coverage --region MN908947.3:22,248-22,428 \
-            -o {sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt ${bam}
+            -o ${sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt ${bam}
 
     }
 

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -409,12 +409,12 @@ task get_primer_site_variants {
     command <<<
 
         bcftools view --regions-file ~{s_gene_primer_bed} --no-header ~{variants} \
-            | tee ~{sample_id}_primer_variants.txt
+            | tee ~{sample_id}_S_gene_primer_variants.txt
 
     >>>
 
     output {
-        File primer_site_variants = "${sample_id}_primer_variants.txt"
+        File primer_site_variants = "${sample_id}_S_gene_primer_variants.txt"
     }
 
     runtime {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -252,6 +252,10 @@ task Bam_stats {
 
     command <<<
 
+        cp ~{bam} .
+        cp ~{bai} .
+        ls
+
         samtools flagstat ~{bam} > ~{sample_id}_~{barcode}_flagstat.txt
 
         samtools stats ~{bam} > ~{sample_id}_~{barcode}_stats.txt
@@ -286,7 +290,7 @@ task Bam_stats {
         do
             echo "Calculating depth for amplicon ${amplicon_names[$c]}"
             samtools coverage --region MN908947.3:${amplicon_coords[$c]} \
-                -o ${sample_id}_${barcode}_amplicon_${amplicon_names[$c]}_coverage.txt ~{bam}
+                -o ${sample_id}_${barcode}_amplicon_${amplicon_names[$c]}_coverage.txt *.bam
         done
         
     >>>

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -228,6 +228,19 @@ task Bam_stats {
 
         samtools coverage -o ${sample_id}_${barcode}_coverage.txt ${bam}
 
+        # Calculate depth of coverage over entire S gene
+        samtools coverage --region MN908947.3:21,563-25,384 \
+            -o {sample_id}_${barcode}_S_gene_coverage.txt ${bam}
+
+        # Calculate depth of coverage over S gene amplicon region containing aa positions 69 and 70
+        samtools coverage --region MN908947.3:21,676-21,889 \
+            -o {sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt ${bam}
+
+
+        # Calculate depth of coverage over S gene amplicon region with Artic V4.1 XBB dropout
+        samtools coverage --region MN908947.3:22,248-22,428 \
+            -o {sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt ${bam}
+
     }
 
     output {
@@ -236,6 +249,9 @@ task Bam_stats {
         File stats_out  = "${sample_id}_${barcode}_stats.txt"
         File covhist_out  = "${sample_id}_${barcode}_coverage_hist.txt"
         File cov_out  = "${sample_id}_${barcode}_coverage.txt"
+        File cov_s_gene_out = "{sample_id}_${barcode}_S_gene_coverage.txt"
+        File cov_s_gene_69_70_out = "{sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt"
+        File cov_s_gene_xbb_drop_out = "{sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt"
     }
 
     runtime {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -267,7 +267,7 @@ task Bam_stats {
         bootDiskSizeGb:    10
         preemptible:    0
         maxRetries:    0
-        docker:    "staphb/samtools:1.10"
+        docker:    "staphb/samtools:1.16"
     }
 }
 

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -238,15 +238,39 @@ task Bam_stats {
         samtools coverage --region MN908947.3:21,563-25,384 \
             -o ${sample_id}_${barcode}_S_gene_coverage.txt ${bam}
 
-        # Calculate depth of coverage over S gene amplicon region containing aa positions 69 and 70
-        samtools coverage --region MN908947.3:21,676-21,889 \
-            -o ${sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt ${bam}
+                
+        # Calculate depth of coverage over S gene amplicon regions. 
 
+        # Artic V4.1 amplicon regions with MN908947.3 as reference. These regions
+        # exclude the overlapping ends with surrounding amplicons. If there are
+        # multiple (alt) primers, the smallest non-overlapping region is selected.
+        # 
+        # Comments annotate domain/region on S gene based on
+        # https://www.uniprot.org/uniprotkb/P0DTC2/entry
+        # Formulas to convert between amino acid position and S gene coords:
+        #     first_codon_nt = 21563 + 3(aa_pos - 1)
+        #     last_codon_nt = 21563 + 3(aa_pos) - 1
 
-        # Calculate depth of coverage over S gene amplicon region with Artic V4.1 XBB dropout
-        samtools coverage --region MN908947.3:22,248-22,428 \
-            -o ${sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt ${bam}
+        declare -A S_gene_amplicons
+        S_gene_amplicons['amplicon_72']='21,676-21,889'  # S1-NTD; 69/70del site
+        S_gene_amplicons['amplicon_73']='21,905-22,113'  # S1-NTD
+        S_gene_amplicons['amplicon_74']='22,248-22,428'  # S1-NTD; XBB dropout
+        S_gene_amplicons['amplicon_75']='22,475-22,677'  # Begin receptor-binding domain
+        S_gene_amplicons['amplicon_76']='22,786-22,974'  # Receptor-binding motif
+        S_gene_amplicons['amplicon_77']='23,121-23,246'  # End eceptor-binding motif/domain
+        S_gene_amplicons['amplicon_78']='23,328-23,575'
+        S_gene_amplicons['amplicon_79']='23,612-23,876'  # Furin cleavage site; putative T-cell superantigen
+        S_gene_amplicons['amplicon_80']='23,928-24,194'  # Host TMPRSS2/CTSL cleavage site
+        S_gene_amplicons['amplicon_81']='24,234-24,448'
+        S_gene_amplicons['amplicon_82']='24,546-24,772'
+        S_gene_amplicons['amplicon_83']='24,815-25,076'
+        S_gene_amplicons['amplicon_84']='25,123-25,353'  # ER export motif, membrane localizing domain binding
 
+        for region in "${!S_gene_amplicons[@]}"; do
+            samtools coverage \
+                --region MN908947.3:${S_gene_amplicons[$region]} ${bam} \
+                -o ${sample_id}_${barcode}_${region}_coverage.txt ${bam}
+        done
     }
 
     output {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -239,38 +239,6 @@ task Bam_stats {
             -o ${sample_id}_${barcode}_S_gene_coverage.txt ${bam}
 
                 
-        # Calculate depth of coverage over S gene amplicon regions. 
-
-        # Artic V4.1 amplicon regions with MN908947.3 as reference. These regions
-        # exclude the overlapping ends with surrounding amplicons. If there are
-        # multiple (alt) primers, the smallest non-overlapping region is selected.
-        # 
-        # Comments annotate domain/region on S gene based on
-        # https://www.uniprot.org/uniprotkb/P0DTC2/entry
-        # Formulas to convert between amino acid position and S gene coords:
-        #     first_codon_nt = 21563 + 3(aa_pos - 1)
-        #     last_codon_nt = 21563 + 3(aa_pos) - 1
-
-        declare -A S_gene_amplicons
-        S_gene_amplicons['amplicon_72']='21,676-21,889'  # S1-NTD; 69/70del site
-        S_gene_amplicons['amplicon_73']='21,905-22,113'  # S1-NTD
-        S_gene_amplicons['amplicon_74']='22,248-22,428'  # S1-NTD; XBB dropout
-        S_gene_amplicons['amplicon_75']='22,475-22,677'  # Begin receptor-binding domain
-        S_gene_amplicons['amplicon_76']='22,786-22,974'  # Receptor-binding motif
-        S_gene_amplicons['amplicon_77']='23,121-23,246'  # End eceptor-binding motif/domain
-        S_gene_amplicons['amplicon_78']='23,328-23,575'
-        S_gene_amplicons['amplicon_79']='23,612-23,876'  # Furin cleavage site; putative T-cell superantigen
-        S_gene_amplicons['amplicon_80']='23,928-24,194'  # Host TMPRSS2/CTSL cleavage site
-        S_gene_amplicons['amplicon_81']='24,234-24,448'
-        S_gene_amplicons['amplicon_82']='24,546-24,772'
-        S_gene_amplicons['amplicon_83']='24,815-25,076'
-        S_gene_amplicons['amplicon_84']='25,123-25,353'  # ER export motif, membrane localizing domain binding
-
-        # for region in "${!S_gene_amplicons[@]}"; do
-        #     samtools coverage \
-        #         --region MN908947.3:${S_gene_amplicons[$region]} ${bam} \
-        #         -o ${sample_id}_${barcode}_${region}_coverage.txt ${bam}
-        # done
     }
 
     output {
@@ -291,7 +259,7 @@ task Bam_stats {
         bootDiskSizeGb:    10
         preemptible:    0
         maxRetries:    0
-        docker:    "staphb/samtools:1.10"
+        docker:    "staphb/samtools:1.16"
     }
 }
 

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -223,7 +223,6 @@ task Bam_stats {
         File bam
         File bai
         File s_gene_amplicons
-        Int num_amplicons = length(amplicon_names)
     }
 
     Int disk_size = 3 * ceil(size(bam, "GB"))

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -259,15 +259,13 @@ task Bam_stats {
                 line=$(echo -e "${amplicon}\t${coords}\t${description}\t")
 
                 # extract mean amplicon depth from samtools coverage output
-                line+=$(staphb-tk samtools coverage \
-                            --region MN908947.3:${coords} ~{bam} \
+                line+=$(samtools coverage --region MN908947.3:${coords} ~{bam} \
                             | cut -f 7 | sed '2q;d')
 
                 echo -e "$line" | tee -a $s_gene_depths
             done
         } < ~{s_gene_amplicons}
-        
-        
+
     >>>
 
     output {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -10,7 +10,29 @@ workflow SC2_ont_assembly {
         File    covid_genome
         File    preprocess_python_script
         File    primer_bed
+        Array[Pair[Int, String]] artic_v4_1_s_gene_amplicons = [
+            (72, '21,676-21,889'), # S1-NTD; 69/70del site
+            (73, '21,905-22,113'), # S1-NTD
+            (74, '22,248-22,428'), # S1-NTD; XBB dropout
+            (75, '22,475-22,677'), # Begin receptor-binding domain
+            (76, '22,786-22,974'), # Receptor-binding motif
+            (77, '23,121-23,246'), # End receptor-binding motif/domain
+            (78, '23,328-23,575'), 
+            (79, '23,612-23,876'), # Furin cleavage site; putative T-cell superantigen
+            (80, '23,928-24,194'), # Host TMPRSS2/CTSL cleavage site
+            (81, '24,234-24,448'), 
+            (82, '24,546-24,772'), 
+            (83, '24,815-25,076'), 
+            (84, '25,123-25,353'), # ER export motif, membrane localizing domain binding
+        ]
     }
+    
+    scatter (pair in artic_v4_1_s_gene_amplicons) {
+        Int amplicon_names = pair.left
+        String amplicon_coords = pair.right
+    }
+    
+    
     call ListFastqFiles {
         input:
             gcs_fastq_dir = gcs_fastq_dir
@@ -37,9 +59,12 @@ workflow SC2_ont_assembly {
     call Bam_stats {
         input:
             bam = Medaka.trimsort_bam,
-            bai = Medaka.trimsort_bai,
+            bai = Medaka.trimsort_bam,
             sample_id = sample_id,
-            barcode = barcode
+            barcode = barcode,
+            amplicon_names = amplicon_names,
+            amplicon_coords = amplicon_coords
+            
     }
     call Scaffold {
         input:
@@ -74,8 +99,7 @@ workflow SC2_ont_assembly {
         File covhist_out = Bam_stats.covhist_out
         File cov_out = Bam_stats.cov_out
         File cov_s_gene_out = Bam_stats.cov_s_gene_out
-        File cov_s_gene_69_70_out = Bam_stats.cov_s_gene_69_70_out
-        File cov_s_gene_xbb_drop_out = Bam_stats.cov_s_gene_xbb_drop_out
+        Array[File] cov_amplicons_out = Bam_stats.cov_amplicons_out
         File variants = Medaka.variants
         File consensus = Medaka.consensus
         File scaffold_consensus = Scaffold.scaffold_consensus
@@ -219,27 +243,53 @@ task Bam_stats {
         String barcode
         File bam
         File bai
+        Array[Int] amplicon_names
+        Array[String] amplicon_coords
+        Int num_amplicons = length(amplicon_names)
     }
 
     Int disk_size = 3 * ceil(size(bam, "GB"))
 
-    command {
+    command <<<
 
-        samtools flagstat ${bam} > ${sample_id}_${barcode}_flagstat.txt
+        samtools flagstat ~{bam} > ~{sample_id}_~{barcode}_flagstat.txt
 
-        samtools stats ${bam} > ${sample_id}_${barcode}_stats.txt
+        samtools stats ~{bam} > ~{sample_id}_~{barcode}_stats.txt
 
-        samtools coverage -m -o ${sample_id}_${barcode}_coverage_hist.txt ${bam}
+        samtools coverage -m -o ~{sample_id}_~{barcode}_coverage_hist.txt ~{bam}
 
-        samtools coverage -o ${sample_id}_${barcode}_coverage.txt ${bam}
+
+        samtools coverage -o ~{sample_id}_~{barcode}_coverage.txt ~{bam}
 
 
         # Calculate depth of coverage over entire S gene
+        echo "Calculating overall S gene depth"
         samtools coverage --region MN908947.3:21,563-25,384 \
-            -o ${sample_id}_${barcode}_S_gene_coverage.txt ${bam}
+            -o ~{sample_id}_~{barcode}_S_gene_coverage.txt ~{bam}
 
-                
-    }
+        # Calculate depth of coverage over S gene amplicon regions. 
+
+        # Artic V4.1 amplicon regions with MN908947.3 as reference. These regions
+        # exclude the overlapping ends with surrounding amplicons. If there are
+        # multiple (alt) primers, the smallest non-overlapping region is selected.
+        # 
+        # Comments annotate domain/region on S gene based on
+        # https://www.uniprot.org/uniprotkb/P0DTC2/entry
+        # Formulas to convert between amino acid position and S gene coords:
+        #     first_codon_nt = 21563 + 3(aa_pos - 1)
+        #     last_codon_nt = 21563 + 3(aa_pos) - 1
+        
+        amplicon_names=(~{sep=" " amplicon_names})
+        amplicon_coords=(~{sep=" " amplicon_coords})
+        
+        for (( c=0; c<~{num_amplicons}; c++ ))
+        do
+            echo "Calculating depth for amplicon ${amplicon_names[$c]}"
+            samtools coverage --region MN908947.3:${amplicon_coords[$c]} \
+                -o ${sample_id}_${barcode}_amplicon_${amplicon_names[$c]}_coverage.txt ~{bam}
+        done
+        
+    >>>
 
     output {
 
@@ -248,8 +298,7 @@ task Bam_stats {
         File covhist_out  = "${sample_id}_${barcode}_coverage_hist.txt"
         File cov_out  = "${sample_id}_${barcode}_coverage.txt"
         File cov_s_gene_out = "${sample_id}_${barcode}_S_gene_coverage.txt"
-        File cov_s_gene_69_70_out = "${sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt"
-        File cov_s_gene_xbb_drop_out = "${sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt"
+        Array[File] cov_amplicons_out = glob("*amplicon*.txt")
     }
 
     runtime {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -206,9 +206,6 @@ task Medaka {
         artic -v > VERSION
         artic minion --medaka --medaka-model r941_min_high_g360 --normalise 20000 --threads 8 --scheme-directory ./primer-schemes --read-file ~{filtered_reads} nCoV-2019/Vuser ~{sample_id}_~{barcode}
 
-        # create VCF index file for get_primer_site_variants task
-        tabix ~{sample_id}_~{barcode}.pass.vcf.gz
-
     >>>
 
     output {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -286,7 +286,7 @@ task Bam_stats {
         do
             echo "Calculating depth for amplicon ${amplicon_names[$c]}"
             samtools coverage --region MN908947.3:${amplicon_coords[$c]} \
-                -o ${sample_id}_${barcode}_amplicon_${amplicon_names[$c]}_coverage.txt ~{bam}
+                -o ~{sample_id}_~{barcode}_amplicon_${amplicon_names[$c]}_coverage.txt ~{bam}
         done
         
     >>>

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -73,6 +73,9 @@ workflow SC2_ont_assembly {
         File samstats_out = Bam_stats.stats_out
         File covhist_out = Bam_stats.covhist_out
         File cov_out = Bam_stats.cov_out
+        File cov_s_gene_out = Bam_stats.cov_s_gene_out
+        File cov_s_gene_69_70_out = Bam_stats.cov_s_gene_69_70_out
+        File cov_s_gene_xbb_drop_out = Bam_stats.cov_s_gene_xbb_drop_out
         File variants = Medaka.variants
         File consensus = Medaka.consensus
         File scaffold_consensus = Scaffold.scaffold_consensus

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -265,7 +265,7 @@ task Bam_stats {
 
                 echo -e "$line" | tee -a $s_gene_depths
             done
-        } < $s_gene_amplicons
+        } < ~{s_gene_amplicons}
         
         
     >>>

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -59,7 +59,7 @@ workflow SC2_ont_assembly {
     call Bam_stats {
         input:
             bam = Medaka.trimsort_bam,
-            bai = Medaka.trimsort_bam,
+            bai = Medaka.trimsort_bai,
             sample_id = sample_id,
             barcode = barcode,
             amplicon_names = amplicon_names,
@@ -251,10 +251,6 @@ task Bam_stats {
     Int disk_size = 3 * ceil(size(bam, "GB"))
 
     command <<<
-
-        cp ~{bam} .
-        cp ~{bai} .
-        ls
 
         samtools flagstat ~{bam} > ~{sample_id}_~{barcode}_flagstat.txt
 

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -37,6 +37,7 @@ workflow SC2_ont_assembly {
     call Bam_stats {
         input:
             bam = Medaka.trimsort_bam,
+            bai = Medaka.trimsort_bai,
             sample_id = sample_id,
             barcode = barcode
     }
@@ -214,6 +215,7 @@ task Bam_stats {
         String sample_id
         String barcode
         File bam
+        File bai
     }
 
     Int disk_size = 3 * ceil(size(bam, "GB"))
@@ -227,6 +229,7 @@ task Bam_stats {
         samtools coverage -m -o ${sample_id}_${barcode}_coverage_hist.txt ${bam}
 
         samtools coverage -o ${sample_id}_${barcode}_coverage.txt ${bam}
+
 
         # Calculate depth of coverage over entire S gene
         samtools coverage --region MN908947.3:21,563-25,384 \

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -207,7 +207,7 @@ task Medaka {
         artic minion --medaka --medaka-model r941_min_high_g360 --normalise 20000 --threads 8 --scheme-directory ./primer-schemes --read-file ~{filtered_reads} nCoV-2019/Vuser ~{sample_id}_~{barcode}
 
         # create VCF index file for get_primer_site_variants task
-        tabix ${sample_id}_${barcode}.pass.vcf.gz
+        tabix ~{sample_id}_~{barcode}.pass.vcf.gz
 
     >>>
 

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -291,7 +291,7 @@ task Bam_stats {
         bootDiskSizeGb:    10
         preemptible:    0
         maxRetries:    0
-        docker:    "staphb/samtools:1.16"
+        docker:    "staphb/samtools:1.10"
     }
 }
 

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -249,9 +249,9 @@ task Bam_stats {
         File stats_out  = "${sample_id}_${barcode}_stats.txt"
         File covhist_out  = "${sample_id}_${barcode}_coverage_hist.txt"
         File cov_out  = "${sample_id}_${barcode}_coverage.txt"
-        File cov_s_gene_out = "{sample_id}_${barcode}_S_gene_coverage.txt"
-        File cov_s_gene_69_70_out = "{sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt"
-        File cov_s_gene_xbb_drop_out = "{sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt"
+        File cov_s_gene_out = "${sample_id}_${barcode}_S_gene_coverage.txt"
+        File cov_s_gene_69_70_out = "${sample_id}_${barcode}_S_gene_69_70_amplicon_coverage.txt"
+        File cov_s_gene_xbb_drop_out = "${sample_id}_${barcode}_S_gene_XBB_dropout_amplicon_coverage.txt"
     }
 
     runtime {

--- a/workflows/WDLs/SC2_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_ont_assembly.wdl
@@ -286,7 +286,7 @@ task Bam_stats {
         do
             echo "Calculating depth for amplicon ${amplicon_names[$c]}"
             samtools coverage --region MN908947.3:${amplicon_coords[$c]} \
-                -o ${sample_id}_${barcode}_amplicon_${amplicon_names[$c]}_coverage.txt *.bam
+                -o ${sample_id}_${barcode}_amplicon_${amplicon_names[$c]}_coverage.txt ~{bam}
         done
         
     >>>

--- a/workflows/WDLs/SC2_transfer_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_transfer_ont_assembly.wdl
@@ -82,7 +82,7 @@ task transfer_outputs {
 
     runtime {
         docker: "theiagen/utility:1.0"
-        memory: "16 GB"
+        memory: "1 GB"
         cpu: 4
         disks: "local-disk 100 SSD"
     }

--- a/workflows/WDLs/SC2_transfer_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_transfer_ont_assembly.wdl
@@ -12,6 +12,9 @@ workflow SC2_transfer_ont_assembly {
         Array[File] variants
         Array[File] scaffold_consensus
         Array[File] renamed_consensus
+        Array[File] cov_s_gene_out
+        Array[File] cov_s_gene_amplicons_out
+        Array[File] primer_site_variants
         Array[String] out_dir
     }
 
@@ -23,9 +26,12 @@ workflow SC2_transfer_ont_assembly {
             samstats_out = samstats_out,
             covhist_out = covhist_out,
             cov_out = cov_out,
+            cov_s_gene_out = cov_s_gene_out,
+            cov_s_gene_amplicons_out = cov_s_gene_amplicons_out,
             variants = variants,
             scaffold_consensus = scaffold_consensus,
             renamed_consensus = renamed_consensus,
+            primer_site_variants = primer_site_variants,
             out_dir = out_dir
     }
     
@@ -42,9 +48,12 @@ task transfer_outputs {
         Array[File] samstats_out
         Array[File] covhist_out
         Array[File] cov_out
+        Array[File] cov_s_gene_out
+        Array[File] cov_s_gene_amplicons_out
         Array[File] variants
         Array[File] scaffold_consensus
         Array[File] renamed_consensus
+        Array[File] primer_site_variants
         Array[String] out_dir
     }
     
@@ -59,8 +68,11 @@ task transfer_outputs {
         gsutil -m cp ~{sep=' ' samstats_out} ~{outdirpath}/bam_stats/
         gsutil -m cp ~{sep=' ' covhist_out} ~{outdirpath}/bam_stats/
         gsutil -m cp ~{sep=' ' cov_out} ~{outdirpath}/bam_stats/
+        gsutil -m cp ~{sep=' ' cov_s_gene_out} ~{outdirpath}/bam_stats/
+        gsutil -m cp ~{sep=' ' cov_s_gene_amplicons_out} ~{outdirpath}/bam_stats/
         gsutil -m cp ~{sep=' ' scaffold_consensus} ~{outdirpath}/assemblies/
         gsutil -m cp ~{sep=' ' variants} ~{outdirpath}/variants/
+        gsutil -m cp ~{sep=' ' primer_site_variants} ~{outdirpath}/primer_site_variants/
         gsutil -m cp ~{sep=' ' renamed_consensus} ~{outdirpath}/assemblies/
         
         transferdate=`date`

--- a/workflows/WDLs/SC2_transfer_ont_assembly.wdl
+++ b/workflows/WDLs/SC2_transfer_ont_assembly.wdl
@@ -3,19 +3,19 @@ version 1.0
 workflow SC2_transfer_ont_assembly {
 
     input {
-        Array[File] filtered_fastq
-        Array[File] trimsort_bam
-        Array[File] flagstat_out
-        Array[File] samstats_out
-        Array[File] covhist_out
-        Array[File] cov_out
-        Array[File] variants
-        Array[File] scaffold_consensus
-        Array[File] renamed_consensus
-        Array[File] cov_s_gene_out
-        Array[File] cov_s_gene_amplicons_out
-        Array[File] primer_site_variants
-        Array[String] out_dir
+        File filtered_fastq
+        File trimsort_bam
+        File flagstat_out
+        File samstats_out
+        File covhist_out
+        File cov_out
+        File variants
+        File scaffold_consensus
+        File renamed_consensus
+        File cov_s_gene_out
+        File cov_s_gene_amplicons_out
+        File primer_site_variants
+        String out_dir
     }
 
     call transfer_outputs {
@@ -42,38 +42,35 @@ workflow SC2_transfer_ont_assembly {
 
 task transfer_outputs {
     input {
-        Array[File] filtered_fastq
-        Array[File] trimsort_bam
-        Array[File] flagstat_out
-        Array[File] samstats_out
-        Array[File] covhist_out
-        Array[File] cov_out
-        Array[File] cov_s_gene_out
-        Array[File] cov_s_gene_amplicons_out
-        Array[File] variants
-        Array[File] scaffold_consensus
-        Array[File] renamed_consensus
-        Array[File] primer_site_variants
-        Array[String] out_dir
+        File filtered_fastq
+        File trimsort_bam
+        File flagstat_out
+        File samstats_out
+        File covhist_out
+        File cov_out
+        File cov_s_gene_out
+        File cov_s_gene_amplicons_out
+        File variants
+        File scaffold_consensus
+        File renamed_consensus
+        File primer_site_variants
+        String out_dir
     }
-    
-    String outdir = '${out_dir[0]}'
-    String outdirpath = sub(outdir, "/$", "")
 
     command <<<
         
-        gsutil -m cp ~{sep=' ' filtered_fastq} ~{outdirpath}/filtered_fastq/
-        gsutil -m cp ~{sep=' ' trimsort_bam} ~{outdirpath}/alignments/
-        gsutil -m cp ~{sep=' ' flagstat_out} ~{outdirpath}/bam_stats/
-        gsutil -m cp ~{sep=' ' samstats_out} ~{outdirpath}/bam_stats/
-        gsutil -m cp ~{sep=' ' covhist_out} ~{outdirpath}/bam_stats/
-        gsutil -m cp ~{sep=' ' cov_out} ~{outdirpath}/bam_stats/
-        gsutil -m cp ~{sep=' ' cov_s_gene_out} ~{outdirpath}/bam_stats/
-        gsutil -m cp ~{sep=' ' cov_s_gene_amplicons_out} ~{outdirpath}/bam_stats/
-        gsutil -m cp ~{sep=' ' scaffold_consensus} ~{outdirpath}/assemblies/
-        gsutil -m cp ~{sep=' ' variants} ~{outdirpath}/variants/
-        gsutil -m cp ~{sep=' ' primer_site_variants} ~{outdirpath}/primer_site_variants/
-        gsutil -m cp ~{sep=' ' renamed_consensus} ~{outdirpath}/assemblies/
+        gsutil -m cp ~{filtered_fastq} ~{out_dir}/filtered_fastq/
+        gsutil -m cp ~{trimsort_bam} ~{out_dir}/alignments/
+        gsutil -m cp ~{flagstat_out} ~{out_dir}/bam_stats/
+        gsutil -m cp ~{samstats_out} ~{out_dir}/bam_stats/
+        gsutil -m cp ~{covhist_out} ~{out_dir}/bam_stats/
+        gsutil -m cp ~{cov_out} ~{out_dir}/bam_stats/
+        gsutil -m cp ~{cov_s_gene_out} ~{out_dir}/bam_stats/
+        gsutil -m cp ~{cov_s_gene_amplicons_out} ~{out_dir}/bam_stats/
+        gsutil -m cp ~{scaffold_consensus} ~{out_dir}/assemblies/
+        gsutil -m cp ~{variants} ~{out_dir}/variants/
+        gsutil -m cp ~{primer_site_variants} ~{out_dir}/primer_site_variants/
+        gsutil -m cp ~{renamed_consensus} ~{out_dir}/assemblies/
         
         transferdate=`date`
         echo $transferdate | tee TRANSFERDATE


### PR DESCRIPTION
### SC2_ont_assembly.wdl: 
- Add additional `samtools coverage` calls to `Bam_stats` task for calculating S gene coverage statistics, for both the S gene amplicons (non-overalapping regions) and the entire S gene. 
- Update docker for `Bam_stats` to use staphb/samtools v1.16 rather than v1.10 because was running into problems calculating coverage over specific regions using the older version.
- To facilitate the amplicon calculations, workflow takes `s_gene_primer_bed` file and` s_gene_amplicon` files as input. Two corresponding files for the Artic V4.1 primers were added to the Terra workspace data. New files can be added to the workspace data for new Artic releases.
- Workflow now outputs `cov_s_gene_out` and `cov_s_amplicons_out`, with the S gene overall coverage and S gene amplicon coverage statistics, respectively.
- Add `get_primer_site_variants` task and `primer_site_variants` WDL output. This new task uses the `s_gene_primer_bed` file input (but could be modified to cover more amplicons in other genes), and outputs a partial VCF of variants in primer-binding sites.
- The new outputs should be useful for determining where there may be blindspots as a result of primer-genome mismatches in the current amplicon scheme. @sam-baird is working on developing a Colab notebook for using the new output files to summarize where blindspots exist.

### SC2_lineage_calling_and_results.wdl:
- Increase CPUs and disks in some tasks to improve speed, especially with slow Cromwell file localization.
- Use multithreading in `pangolin` task for speed improvements.

### SC2_transfer_ont_assembly.wdl:
- Improve transfer speed by parallelizing workflow to operate on each sample rather than the sample set. Inputs are no longer Array types (e.g. `Array[File]`), but individual types (e.g. `File`).
- Consequence of this is now this workflow is run on Terra for each sample (does not use the set entity type anymore). No longer have to launch workflow for each COVMIN batch.